### PR TITLE
Shared event pool

### DIFF
--- a/src/event_handler.cpp
+++ b/src/event_handler.cpp
@@ -54,6 +54,9 @@ void event_handler::handle_event(void *ctx, int cpu, void *data, unsigned int da
         std::cout<<_serializer->serialize_write_event(reinterpret_cast<struct_write_syscall*>(data))<<std::endl;
         break;
     }       
+    case SYS_open:
+        std::cout<<"OPEN******\n"; //todo:
+        break;
     default:
         break;
     }

--- a/src/kern/common.h
+++ b/src/kern/common.h
@@ -6,7 +6,6 @@
     char fmt[] = format;        \
     bpf_trace_printk(fmt, sizeof(fmt), ##__VA_ARGS__);
 
-#define PT_REGS_RC(x) ((x)->ax)
 #define PT_REGS_ORIG_AX(x) ((x)->orig_ax)
 
 __attribute__((always_inline)) static inline bool set_args(unsigned long *arg, const struct pt_regs *regs)

--- a/src/kern/lyncean.bpf.c
+++ b/src/kern/lyncean.bpf.c
@@ -20,7 +20,7 @@ int tail_raw_syscall_read_exit(struct __raw_tracepoint_args *ctx)
         goto out;
     }
     void *ptr_start = (void *)read_struct;
-    void *ptr_end = (void*)read_struct->buff;
+    void *ptr_end = (void *)read_struct->buff;
     read_struct->fd = args->arg[0];
     read_struct->syscallid = args->syscallid;
     read_struct->count = args->arg[2];
@@ -35,14 +35,15 @@ int tail_raw_syscall_read_exit(struct __raw_tracepoint_args *ctx)
     {
         ptr_end += size;
     }
-    else{
-        BPF_PRINTK("ERROR, tail_raw_syscall_read_exit, bpd_probe_read failed.\n");  
+    else
+    {
+        BPF_PRINTK("ERROR, tail_raw_syscall_read_exit, bpd_probe_read failed.\n");
     }
     __u64 len = ptr_end - ptr_start;
     int ret = bpf_perf_event_output(ctx, &perf_buff, BPF_F_CURRENT_CPU, ptr_start, len < MAX_EVENT_SIZE ? len : 0);
     if (ret != 0)
     {
-        BPF_PRINTK("ERROR, output to perf buffer, code: %ld", ret);
+        BPF_PRINTK("ERROR, output to perf buffer, code:%ld, syscallid:%d", ret, args->syscallid);
     }
 out:
     bpf_map_delete_elem(&syscall_args_map, &pidtid);
@@ -68,7 +69,7 @@ int tail_raw_syscall_write_exit(struct __raw_tracepoint_args *ctx)
         goto out;
     }
     void *ptr_start = (void *)write_struct;
-    void *ptr_end = (void*)write_struct->buff;
+    void *ptr_end = (void *)write_struct->buff;
     write_struct->fd = args->arg[0];
     write_struct->syscallid = args->syscallid;
     write_struct->count = args->arg[2];
@@ -84,14 +85,15 @@ int tail_raw_syscall_write_exit(struct __raw_tracepoint_args *ctx)
     {
         ptr_end += size;
     }
-    else{
-        BPF_PRINTK("ERROR, tail_raw_syscall_write_exit, bpd_probe_read failed.\n"); 
-    }   
+    else
+    {
+        BPF_PRINTK("ERROR, tail_raw_syscall_write_exit, bpd_probe_read failed.\n");
+    }
     __u64 len = ptr_end - ptr_start;
     int ret = bpf_perf_event_output(ctx, &perf_buff, BPF_F_CURRENT_CPU, ptr_start, len < MAX_EVENT_SIZE ? len : 0);
     if (ret != 0)
     {
-        BPF_PRINTK("ERROR, output to perf buffer, code: %ld", ret);
+        BPF_PRINTK("ERROR, output to perf buffer, code:%ld, syscallid:%d", ret, args->syscallid);
     }
 out:
     bpf_map_delete_elem(&syscall_args_map, &pidtid);
@@ -117,27 +119,28 @@ int tail_raw_syscall_open_exit(struct __raw_tracepoint_args *ctx)
         goto out;
     }
     void *ptr_start = (void *)open_struct;
-    void *ptr_end = (void*)open_struct->pathname;
+    void *ptr_end = (void *)open_struct->pathname;
     open_struct->syscallid = args->syscallid;
     open_struct->flag = args->arg[1];
     open_struct->mode = args->arg[2];
     if (bpf_probe_read(&open_struct->rc, sizeof(int), (void *)&PT_REGS_RC((struct pt_regs *)ctx->args[0])) != 0)
     {
         BPF_PRINTK("ERROR, failed to get return code\n");
-    }    
-    long size=0;
-    if (size = bpf_probe_read_str(open_struct->pathname, MAX_PATH, (void *)args->arg[0]) > 0)
+    }
+    long size = bpf_probe_read_str(open_struct->pathname, MAX_PATH, (void *)args->arg[0]);
+    if (size > 0)
     {
         ptr_end += size;
     }
-    else{
-       BPF_PRINTK("ERROR, tail_raw_syscall_open_exit, bpd_probe_open failed.\n");
+    else
+    {
+        BPF_PRINTK("ERROR, tail_raw_syscall_open_exit, bpd_probe_open failed.\n");
     }
-     __u64 len = ptr_end - ptr_start;
+    __u64 len = ptr_end - ptr_start;
     int ret = bpf_perf_event_output(ctx, &perf_buff, BPF_F_CURRENT_CPU, ptr_start, len < MAX_EVENT_SIZE ? len : 0);
     if (ret != 0)
     {
-        BPF_PRINTK("ERROR, output to perf buffer, code: %ld", ret);
+        BPF_PRINTK("ERROR, output to perf buffer, code:%ld, syscallid:%d", ret, args->syscallid);
     }
 out:
     bpf_map_delete_elem(&syscall_args_map, &pidtid);

--- a/src/kern/lyncean.bpf.c
+++ b/src/kern/lyncean.bpf.c
@@ -13,30 +13,33 @@ int tail_raw_syscall_read_exit(struct __raw_tracepoint_args *ctx)
     }
     uint32_t cpu = bpf_get_smp_processor_id();
     struct_read_syscall *read_struct = NULL;
-    read_struct = bpf_map_lookup_elem(&read_struct_pool, &cpu);
+    read_struct = bpf_map_lookup_elem(&event_pool, &cpu);
     if (!read_struct)
     {
         BPF_PRINTK("ERROR, lookup from read_struct_pool failed\n");
         goto out;
     }
+    void *ptr_start = (void *)read_struct;
+    void *ptr_end = (void*)read_struct->buff;
     read_struct->fd = args->arg[0];
-   // memset(read_struct->buff, 0, MAX_DATA_WR_RD);
     read_struct->syscallid = args->syscallid;
     read_struct->count = args->arg[2];
     if (bpf_probe_read(&read_struct->rc, sizeof(int64_t), (void *)&PT_REGS_RC((struct pt_regs *)ctx->args[0])) != 0)
     {
         BPF_PRINTK("ERROR, failed to get return code\n");
     }
-
     u32 size = read_struct->rc;
     asm volatile("%[size] &= 16383\n"
                  : [size] "+&r"(size));
-    if (bpf_probe_read(read_struct->buff, size, (void *)args->arg[1]) != 0)
+    if (bpf_probe_read(read_struct->buff, size, (void *)args->arg[1]) == 0)
     {
-        BPF_PRINTK("ERROR, tail_raw_syscall_read_exit, bpd_probe_read failed.\n");
+        ptr_end += size;
     }
-    BPF_PRINTK("sizeof struct:%ld", sizeof(struct_read_syscall));
-    int ret = bpf_perf_event_output(ctx, &perf_buff, BPF_F_CURRENT_CPU, read_struct, sizeof(struct_read_syscall));
+    else{
+        BPF_PRINTK("ERROR, tail_raw_syscall_read_exit, bpd_probe_read failed.\n");  
+    }
+    __u64 len = ptr_end - ptr_start;
+    int ret = bpf_perf_event_output(ctx, &perf_buff, BPF_F_CURRENT_CPU, ptr_start, len < MAX_EVENT_SIZE ? len : 0);
     if (ret != 0)
     {
         BPF_PRINTK("ERROR, output to perf buffer, code: %ld", ret);
@@ -58,14 +61,15 @@ int tail_raw_syscall_write_exit(struct __raw_tracepoint_args *ctx)
     }
     uint32_t cpu = bpf_get_smp_processor_id();
     struct_write_syscall *write_struct = NULL;
-    write_struct = bpf_map_lookup_elem(&write_struct_pool, &cpu);
+    write_struct = bpf_map_lookup_elem(&event_pool, &cpu);
     if (!write_struct)
     {
         BPF_PRINTK("ERROR, lookup from write_struct_pool failed\n");
         goto out;
     }
+    void *ptr_start = (void *)write_struct;
+    void *ptr_end = (void*)write_struct->buff;
     write_struct->fd = args->arg[0];
-   // memset(read_struct->buff, 0, MAX_DATA_WR_RD);
     write_struct->syscallid = args->syscallid;
     write_struct->count = args->arg[2];
     if (bpf_probe_read(&write_struct->rc, sizeof(int64_t), (void *)&PT_REGS_RC((struct pt_regs *)ctx->args[0])) != 0)
@@ -76,12 +80,15 @@ int tail_raw_syscall_write_exit(struct __raw_tracepoint_args *ctx)
     u32 size = write_struct->rc;
     asm volatile("%[size] &= 16383\n"
                  : [size] "+&r"(size));
-    if (bpf_probe_read(write_struct->buff, size, (void *)args->arg[1]) != 0)
+    if (bpf_probe_read(write_struct->buff, size, (void *)args->arg[1]) == 0)
     {
-        BPF_PRINTK("ERROR, tail_raw_syscall_read_exit, bpd_probe_read failed.\n");
+        ptr_end += size;
     }
-    BPF_PRINTK("sizeof struct:%ld", sizeof(struct_read_syscall));
-    int ret = bpf_perf_event_output(ctx, &perf_buff, BPF_F_CURRENT_CPU, write_struct, sizeof(struct_write_syscall));
+    else{
+        BPF_PRINTK("ERROR, tail_raw_syscall_write_exit, bpd_probe_read failed.\n"); 
+    }   
+    __u64 len = ptr_end - ptr_start;
+    int ret = bpf_perf_event_output(ctx, &perf_buff, BPF_F_CURRENT_CPU, ptr_start, len < MAX_EVENT_SIZE ? len : 0);
     if (ret != 0)
     {
         BPF_PRINTK("ERROR, output to perf buffer, code: %ld", ret);
@@ -103,30 +110,31 @@ int tail_raw_syscall_open_exit(struct __raw_tracepoint_args *ctx)
     }
     uint32_t cpu = bpf_get_smp_processor_id();
     struct_open_syscall *open_struct = NULL;
-    open_struct = bpf_map_lookup_elem(&open_struct_pool, &cpu);
+    open_struct = bpf_map_lookup_elem(&event_pool, &cpu);
     if (!open_struct)
     {
         BPF_PRINTK("ERROR, lookup from open_struct_pool failed\n");
         goto out;
     }
-    
-    u32 size = MAX_PATH;
-    asm volatile("%[size] &= 4096\n"
-                 : [size] "+&r"(size));
-    if (bpf_probe_read(open_struct->pathname, size, (void *)args->arg[0]) != 0)
-    {
-        BPF_PRINTK("ERROR, tail_raw_syscall_open_exit, bpd_probe_open failed.\n");
-    }
-
+    void *ptr_start = (void *)open_struct;
+    void *ptr_end = (void*)open_struct->pathname;
     open_struct->syscallid = args->syscallid;
     open_struct->flag = args->arg[1];
     open_struct->mode = args->arg[2];
     if (bpf_probe_read(&open_struct->rc, sizeof(int), (void *)&PT_REGS_RC((struct pt_regs *)ctx->args[0])) != 0)
     {
         BPF_PRINTK("ERROR, failed to get return code\n");
+    }    
+    long size=0;
+    if (size = bpf_probe_read_str(open_struct->pathname, MAX_PATH, (void *)args->arg[0]) > 0)
+    {
+        ptr_end += size;
     }
-
-    int ret = bpf_perf_event_output(ctx, &perf_buff, BPF_F_CURRENT_CPU, open_struct, sizeof(struct_open_syscall));
+    else{
+       BPF_PRINTK("ERROR, tail_raw_syscall_open_exit, bpd_probe_open failed.\n");
+    }
+     __u64 len = ptr_end - ptr_start;
+    int ret = bpf_perf_event_output(ctx, &perf_buff, BPF_F_CURRENT_CPU, ptr_start, len < MAX_EVENT_SIZE ? len : 0);
     if (ret != 0)
     {
         BPF_PRINTK("ERROR, output to perf buffer, code: %ld", ret);

--- a/src/kern/shared.h
+++ b/src/kern/shared.h
@@ -22,10 +22,10 @@ typedef struct
 typedef struct 
 {
     unsigned long syscallid;
-    char pathname[MAX_PATH];
     int flag; //except creat syscall where the flags equal to O_CREAT|O_WRONLY|O_TRUNC
     mode_t mode;
     int rc;
+    char pathname[MAX_PATH];
 } __attribute__((aligned(8))) struct_open_syscall;
 
 typedef struct 

--- a/src/kern/types.h
+++ b/src/kern/types.h
@@ -11,6 +11,8 @@
 #define MAX_CPU 512
 #define MAX_RUNNING_THREADS 4096
 #define NUM_OF_SYSCALLS 512
+#define MAX_EVENT_SIZE (65536 - 24)
+
 struct __raw_tracepoint_args
 {
     __u64 args[0];
@@ -63,26 +65,10 @@ struct
 struct
 {
     __uint(type, BPF_MAP_TYPE_ARRAY);
-    __type(key, uint32_t);
-    __type(value, struct_read_syscall);
+    __uint(key_size, sizeof(uint32_t));
+    __uint(value_size, MAX_EVENT_SIZE);
     __uint(max_entries, MAX_CPU);
-} read_struct_pool SEC(".maps");
-
-struct
-{
-    __uint(type, BPF_MAP_TYPE_ARRAY);
-    __type(key, uint32_t);
-    __type(value, struct_write_syscall);
-    __uint(max_entries, MAX_CPU);
-} write_struct_pool SEC(".maps");
-
-struct
-{
-    __uint(type, BPF_MAP_TYPE_ARRAY);
-    __type(key, uint32_t);
-    __type(value, struct_open_syscall);
-    __uint(max_entries, MAX_CPU);
-} open_struct_pool SEC(".maps");
+} event_pool SEC(".maps");
 
 struct
 {
@@ -94,8 +80,8 @@ struct
 } prog_array_tailcalls SEC(".maps") = {
     .values = {
         [__NR_read] = (void *)&tail_raw_syscall_read_exit,
-        [__NR_write] = (void*)&tail_raw_syscall_write_exit,
-        [__NR_open] = (void*)&tail_raw_syscall_open_exit,
+        [__NR_write] = (void *)&tail_raw_syscall_write_exit,
+        [__NR_open] = (void *)&tail_raw_syscall_open_exit,
     },
 };
 

--- a/test/bpf_test.cpp
+++ b/test/bpf_test.cpp
@@ -43,8 +43,8 @@ static void global_handle_event(void *ctx, int cpu, void *data, unsigned int dat
     }
     case SYS_open:
     {
-        auto actual_event{reinterpret_cast<struct_open_syscall*>(data)};
-        auto expected_event{reinterpret_cast<struct_open_syscall*>(global_event.buff)};
+        auto actual_event{reinterpret_cast<struct_open_syscall *>(data)};
+        auto expected_event{reinterpret_cast<struct_open_syscall *>(global_event.buff)};
         EXPECT_EQ(actual_event->flag, expected_event->flag);
         EXPECT_EQ(actual_event->mode, expected_event->mode);
         EXPECT_EQ(actual_event->rc, expected_event->rc);
@@ -58,12 +58,26 @@ static void global_handle_event(void *ctx, int cpu, void *data, unsigned int dat
 
 class bpf_test_fixture : public ::testing::Test
 {
+public:
+    bool set_active_syscalls_config(const std::initializer_list<int> &syscalls = {SYS_open, SYS_read, SYS_write, SYS_openat})
+    {
+        bpf_config_struct conf;
+        memset(conf.active, 0, SYSCALL_COUNT_SIZE);
+        conf.target_pid = getpid();
+        for (auto sys : syscalls)
+        {
+            conf.active[sys] = true;
+        }
+        return set_bpf_config(_skel, conf);
+    }
+
 private:
     void load_bpf()
     {
-        auto skel{load_bpf_skeleton(getpid())};
+        auto skel{load_bpf_skeleton()};
         ASSERT_TRUE(skel.has_value());
         _skel = skel.value();
+       // ASSERT_TRUE(set_active_syscalls_config());
         _perf_buff = perf_buffer__new(bpf_map__fd(_skel->maps.perf_buff), 1024, global_handle_event, NULL, NULL, NULL);
         ASSERT_TRUE(_perf_buff);
     }
@@ -96,6 +110,7 @@ perf_buffer *bpf_test_fixture::_perf_buff = nullptr;
 
 TEST_F(bpf_test_fixture, read_system_call)
 {
+    EXPECT_TRUE(set_active_syscalls_config({SYS_read}));
     const char *pathname = "./test_files/test_read.txt";
     int fd = open(pathname, O_RDONLY);
     ASSERT_FALSE(fd < 0);
@@ -120,15 +135,18 @@ TEST_F(bpf_test_fixture, read_system_call)
 
 TEST_F(bpf_test_fixture, open_system_call)
 {
-    const char* pathname = "./test_files/test_read.txt";
+    EXPECT_TRUE(set_active_syscalls_config({SYS_open}));
+    const char *pathname = "./test_files/test_read.txt";
     mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
     int flags = O_RDONLY;
-    int fd = open(pathname, flags, mode);
+    int fd = syscall(SYS_open, pathname, flags, mode);
     ASSERT_FALSE(fd < 0);
     struct_open_syscall event;
     memset(&event, 0, sizeof(struct_open_syscall));
     event.syscallid = SYS_open;
     event.flag = flags;
+    event.rc = fd;
+    event.mode = mode;
     memcpy(event.pathname, pathname, strlen(pathname));
     memset(&global_event, 0, sizeof(event_struct));
     memcpy(global_event.buff, (void *)&event, sizeof(struct_open_syscall));
@@ -140,6 +158,7 @@ TEST_F(bpf_test_fixture, open_system_call)
 
 TEST_F(bpf_test_fixture, write_systemcall)
 {
+    EXPECT_TRUE(set_active_syscalls_config({SYS_write}));
     const char *pathname = "./test_files/write_test.txt";
     int fd = open(pathname, O_WRONLY | O_TRUNC);
     ASSERT_FALSE(fd < 0);


### PR DESCRIPTION
IMP: reducing bpf memory by sharing the same map for storage all events types.
FIX: open syscall test 